### PR TITLE
fix migrations naming conflicts

### DIFF
--- a/migrations/2020_05_12_200432_create_scheduler_watcher_job_event_outputs_table.php
+++ b/migrations/2020_05_12_200432_create_scheduler_watcher_job_event_outputs_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateJobEventOutputsTable extends Migration {
+class CreateSchedulerWatcherJobEventOutputsTable extends Migration {
 
 	/**
 	 * Run the migrations.

--- a/migrations/2020_05_12_200432_create_scheduler_watcher_job_events_table.php
+++ b/migrations/2020_05_12_200432_create_scheduler_watcher_job_events_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateJobEventsTable extends Migration {
+class CreateSchedulerWatcherJobEventsTable extends Migration {
 
 	/**
 	 * Run the migrations.

--- a/migrations/2020_05_12_200432_create_scheduler_watcher_jobs_table.php
+++ b/migrations/2020_05_12_200432_create_scheduler_watcher_jobs_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateJobsTable extends Migration {
+class CreateSchedulerWatcherJobsTable extends Migration {
 
 	/**
 	 * Run the migrations.

--- a/migrations/2020_05_12_200435_add_foreign_keys_to_scheduler_watcher_job_event_outputs_table.php
+++ b/migrations/2020_05_12_200435_add_foreign_keys_to_scheduler_watcher_job_event_outputs_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class AddForeignKeysToJobEventOutputsTable extends Migration {
+class AddForeignKeysToSchedulerWatcherJobEventOutputsTable extends Migration {
 
 	/**
 	 * Run the migrations.

--- a/migrations/2020_05_12_200435_add_foreign_keys_to_scheduler_watcher_job_events_table.php
+++ b/migrations/2020_05_12_200435_add_foreign_keys_to_scheduler_watcher_job_events_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class AddForeignKeysToJobEventsTable extends Migration {
+class AddForeignKeysToSchedulerWatcherJobEventsTable extends Migration {
 
 	/**
 	 * Run the migrations.


### PR DESCRIPTION
I ran into issues with CreateJobTable migration, I already had one.  So I renamed the migrations to prevents conflicts.