### PR TITLE
use correct type for column jobe_exitcode

### DIFF
--- a/migrations/2020_05_12_200432_create_scheduler_watcher_job_events_table.php
+++ b/migrations/2020_05_12_200432_create_scheduler_watcher_job_events_table.php
@@ -17,7 +17,7 @@ class CreateSchedulerWatcherJobEventsTable extends Migration {
             $table->dateTime('jobe_start')->nullable();
             $table->dateTime('jobe_end')->nullable();
             $table->float('jobe_duration', 20, 13)->nullable();
-            $table->boolean('jobe_exitcode')->nullable();
+            $table->smallInteger('jobe_exitcode')->nullable();
             $table->dateTime('jobe_db_created')->nullable();
         });
     }


### PR DESCRIPTION
Datatype value is between 0-255 and no boolean.
Unfortunately only SMALLINT (INT6) is supported by laravel instead of TINYINT (3).